### PR TITLE
Dependencies update (A.K.A., spring cleaning) - March 2025

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atty = "0.2.14"
-clap = "4.5.4"
-env_logger = "0.11.3"
+clap = "4.5.32"
+env_logger = "0.11.7"
 glob = "0.3.2"
 log = "0.4.21"
 vscode-fuzzy-score-rs = { git = "https://github.com/semkiv/vs-code-fuzzy-score-rs.git", tag = "v0.2.6" }
@@ -17,4 +16,4 @@ walkdir = "2.5.0"
 yansi = "1.0.1"
 
 [dev-dependencies]
-tempfile = "3.10.1"
+tempfile = "3.19.1"

--- a/tests/output.rs
+++ b/tests/output.rs
@@ -1,6 +1,8 @@
-use atty::Stream;
 use fzgrep::cli::args;
-use std::str;
+use std::{
+    io::{self, IsTerminal},
+    str,
+};
 use yansi::{Condition, Paint};
 
 #[test]
@@ -13,22 +15,22 @@ fn default_single_file() {
             "contig"
                 .red()
                 .bold()
-                .whenever(Condition::cached(atty::is(Stream::Stdout))),
+                .whenever(Condition::cached(io::stdout().is_terminal())),
             "ous"
                 .red()
                 .bold()
-                .whenever(Condition::cached(atty::is(Stream::Stdout)))
+                .whenever(Condition::cached(io::stdout().is_terminal()))
         ),
         format!(
             "{}u{}\n",
             "Contig"
                 .red()
                 .bold()
-                .whenever(Condition::cached(atty::is(Stream::Stdout))),
+                .whenever(Condition::cached(io::stdout().is_terminal())),
             "ous"
                 .red()
                 .bold()
-                .whenever(Condition::cached(atty::is(Stream::Stdout)))
+                .whenever(Condition::cached(io::stdout().is_terminal()))
         ),
     ]
     .concat();
@@ -51,65 +53,65 @@ fn default_multiple_files() {
             "{}{}{}u{}\n",
             "resources/tests/test.txt"
                 .magenta()
-                .whenever(Condition::cached(atty::is(Stream::Stdout))),
+                .whenever(Condition::cached(io::stdout().is_terminal())),
             ':'.cyan()
-                .whenever(Condition::cached(atty::is(Stream::Stdout))),
+                .whenever(Condition::cached(io::stdout().is_terminal())),
             "contig"
                 .red()
                 .bold()
-                .whenever(Condition::cached(atty::is(Stream::Stdout))),
+                .whenever(Condition::cached(io::stdout().is_terminal())),
             "ous"
                 .red()
                 .bold()
-                .whenever(Condition::cached(atty::is(Stream::Stdout)))
+                .whenever(Condition::cached(io::stdout().is_terminal()))
         ),
         format!(
             "{}{}{}u{}\n",
             "resources/tests/тест.txt"
                 .magenta()
-                .whenever(Condition::cached(atty::is(Stream::Stdout))),
+                .whenever(Condition::cached(io::stdout().is_terminal())),
             ':'.cyan()
-                .whenever(Condition::cached(atty::is(Stream::Stdout))),
+                .whenever(Condition::cached(io::stdout().is_terminal())),
             "contig"
                 .red()
                 .bold()
-                .whenever(Condition::cached(atty::is(Stream::Stdout))),
+                .whenever(Condition::cached(io::stdout().is_terminal())),
             "ous"
                 .red()
                 .bold()
-                .whenever(Condition::cached(atty::is(Stream::Stdout)))
+                .whenever(Condition::cached(io::stdout().is_terminal()))
         ),
         format!(
             "{}{}{}u{}\n",
             "resources/tests/test.txt"
                 .magenta()
-                .whenever(Condition::cached(atty::is(Stream::Stdout))),
+                .whenever(Condition::cached(io::stdout().is_terminal())),
             ':'.cyan()
-                .whenever(Condition::cached(atty::is(Stream::Stdout))),
+                .whenever(Condition::cached(io::stdout().is_terminal())),
             "Contig"
                 .red()
                 .bold()
-                .whenever(Condition::cached(atty::is(Stream::Stdout))),
+                .whenever(Condition::cached(io::stdout().is_terminal())),
             "ous"
                 .red()
                 .bold()
-                .whenever(Condition::cached(atty::is(Stream::Stdout)))
+                .whenever(Condition::cached(io::stdout().is_terminal()))
         ),
         format!(
             "{}{}{}u{}\n",
             "resources/tests/тест.txt"
                 .magenta()
-                .whenever(Condition::cached(atty::is(Stream::Stdout))),
+                .whenever(Condition::cached(io::stdout().is_terminal())),
             ':'.cyan()
-                .whenever(Condition::cached(atty::is(Stream::Stdout))),
+                .whenever(Condition::cached(io::stdout().is_terminal())),
             "Contig"
                 .red()
                 .bold()
-                .whenever(Condition::cached(atty::is(Stream::Stdout))),
+                .whenever(Condition::cached(io::stdout().is_terminal())),
             "ous"
                 .red()
                 .bold()
-                .whenever(Condition::cached(atty::is(Stream::Stdout)))
+                .whenever(Condition::cached(io::stdout().is_terminal()))
         ),
     ]
     .concat();
@@ -489,19 +491,19 @@ fn formatting_color_auto() {
             "{}u{}\n",
             "contig"
                 .blue()
-                .whenever(Condition::cached(atty::is(Stream::Stdout))),
+                .whenever(Condition::cached(io::stdout().is_terminal())),
             "ous"
                 .blue()
-                .whenever(Condition::cached(atty::is(Stream::Stdout)))
+                .whenever(Condition::cached(io::stdout().is_terminal()))
         ),
         format!(
             "{}u{}\n",
             "Contig"
                 .blue()
-                .whenever(Condition::cached(atty::is(Stream::Stdout))),
+                .whenever(Condition::cached(io::stdout().is_terminal())),
             "ous"
                 .blue()
-                .whenever(Condition::cached(atty::is(Stream::Stdout)))
+                .whenever(Condition::cached(io::stdout().is_terminal()))
         ),
     ]
     .concat();
@@ -765,48 +767,100 @@ fn all_options_short() {
             {}{}{}{}{}u{}\n\
             {}{}{}{}Contiguous\n\
             {}{}{}{}Текст\n",
-            "resources/tests/test.txt".magenta().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            ':'.cyan().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            '1'.green().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            ':'.cyan().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            "resources/tests/test.txt".magenta().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            ':'.cyan().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            '2'.green().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            ':'.cyan().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            "contig".red().bold().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            "ous".red().bold().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            "resources/tests/test.txt".magenta().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            ':'.cyan().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            '3'.green().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            ':'.cyan().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            "resources/tests/test.txt".magenta().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            ':'.cyan().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            '4'.green().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            ':'.cyan().whenever(Condition::cached(atty::is(Stream::Stdout))),
+            "resources/tests/test.txt"
+                .magenta()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            ':'.cyan()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            '1'.green()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            ':'.cyan()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            "resources/tests/test.txt"
+                .magenta()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            ':'.cyan()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            '2'.green()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            ':'.cyan()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            "contig"
+                .red()
+                .bold()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            "ous"
+                .red()
+                .bold()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            "resources/tests/test.txt"
+                .magenta()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            ':'.cyan()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            '3'.green()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            ':'.cyan()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            "resources/tests/test.txt"
+                .magenta()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            ':'.cyan()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            '4'.green()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            ':'.cyan()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
         ),
         format!(
             "{}{}{}{}contiguous\n\
             {}{}{}{}{}u{}\n\
             {}{}{}{}Текст\n\
             {}{}{}{}тестування\n",
-            "resources/tests/test.txt".magenta().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            ':'.cyan().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            '2'.green().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            ':'.cyan().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            "resources/tests/test.txt".magenta().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            ':'.cyan().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            '3'.green().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            ':'.cyan().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            "Contig".red().bold().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            "ous".red().bold().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            "resources/tests/test.txt".magenta().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            ':'.cyan().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            '4'.green().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            ':'.cyan().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            "resources/tests/test.txt".magenta().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            ':'.cyan().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            '5'.green().whenever(Condition::cached(atty::is(Stream::Stdout))),
-            ':'.cyan().whenever(Condition::cached(atty::is(Stream::Stdout))),
+            "resources/tests/test.txt"
+                .magenta()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            ':'.cyan()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            '2'.green()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            ':'.cyan()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            "resources/tests/test.txt"
+                .magenta()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            ':'.cyan()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            '3'.green()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            ':'.cyan()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            "Contig"
+                .red()
+                .bold()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            "ous"
+                .red()
+                .bold()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            "resources/tests/test.txt"
+                .magenta()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            ':'.cyan()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            '4'.green()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            ':'.cyan()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            "resources/tests/test.txt"
+                .magenta()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            ':'.cyan()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            '5'.green()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
+            ':'.cyan()
+                .whenever(Condition::cached(io::stdout().is_terminal())),
         ),
     ]
     .concat();


### PR DESCRIPTION
Updated project dependencies:
  * removed a dependency on the unmaintained `atty` crate (the functionality is replaced with `std::io::IsTerminal`).
  * updated dependency crates to the most recent versions available